### PR TITLE
Driver independent from mostjs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,50 +1,33 @@
-import ApolloClient, { createNetworkInterface } from 'apollo-client'
-import most from 'most'
-import graphqlTag from 'graphql-tag'
 
-export const gql = graphqlTag
+export function makeGraphQLDriver ({templates = {}, client}) {
 
-export function makeGraphQLDriver ({templates = {}, endpoint = '/graphql', includeHeaders = {}}) {
-  const networkInterface = createNetworkInterface(endpoint, {credentials: 'include'})
-  networkInterface.use([{
-    applyMiddleware (req, next) {
-      // if some header was sent through input$ it will appear here.
-      // users must make sure any necessary header is sent before actual calls.
-      if (includeHeaders) {
-        req.options.headers = includeHeaders
-      }
-      next()
-    }
-  }])
-  const client = new ApolloClient({networkInterface})
+  return function graphqlDriver (input$, runStreamAdapter) {
 
-  return function graphqlDriver (input$) {
-    // extract headers from the given input, if they come.
-    let headers$ = input$.filter(e => e.headers)
-    headers$.observe(s => {
-      includeHeaders= s.headers
-    })
-
-    // actually make the calls
     let query$ = input$.filter(e => e.query)
     let mutation$ = input$.filter(e => e.mutation)
 
-    let res$$ = most.merge(
-      query$
-        .map(({query, variables, forceFetch = true}) => {
-          query = templates[query] || query
-          let res$ = most.fromPromise(client.query({query, variables, forceFetch}))
-          return res$
-        }),
-      mutation$
-        .map(({mutation, variables}) => {
-          mutation = templates[mutation] || mutation
-          let res$ = most.fromPromise(client.mutate({mutation, variables}))
-          return res$
-        })
-      )
+    const { stream, observer } = runStreamAdapter.makeSubject();
 
-    return res$$
-      .multicast()
+    runStreamAdapter.streamSubscribe(query$,
+      {
+        next: ({query, variables, forceFetch = true}) => {
+          query = templates[query] || query
+          client.query({query, variables, forceFetch})
+            .then( (x) => observer.next(x) )
+            .catch( (err) => observer.error(err) );
+        }
+      });
+    runStreamAdapter.streamSubscribe(query$,
+      {
+        next: ({mutation, variables}) => {
+          mutation = templates[mutation] || mutation
+          client.mutate({mutation, variables})
+            .then( (x) => observer.next(x) )
+            .catch( (err) => observer.error(err) );
+        }
+      });
+
+    return stream;
+
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,12 +28,15 @@
     "graphql"
   ],
   "devDependencies": {
-    "@cycle/most-run": "^4.2.0",
+    "@cycle/most-adapter": "^4.1.0",
+    "assert": "^1.4.1",
     "babel-core": "^6.4.5",
     "babel-preset-es2015": "^6.3.13",
     "babelify": "^7.2.0",
     "browserify": "11.0.1",
-    "mocha": "^3.2.0"
+    "graphql-tag": "^1.0.0",
+    "mocha": "^3.2.0",
+    "most": "^1.1.0"
   },
   "author": "Giovanni T. Parra",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A simple, Apollo-based, GraphQL driver to be used with Cycle's most-run",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./node_modules/.bin/mocha --compilers js:babel-core/register test.js"
   },
   "repository": {
     "type": "git",
@@ -24,22 +24,16 @@
   "keywords": [
     "cycle",
     "cyclejs",
-    "most",
     "driver",
     "graphql"
   ],
-  "dependencies": {
-    "apollo-client": "*",
-    "graphql-tag": "^0.1.13"
-  },
-  "peerDependencies": {
-    "most": "*"
-  },
   "devDependencies": {
+    "@cycle/most-run": "^4.2.0",
     "babel-core": "^6.4.5",
     "babel-preset-es2015": "^6.3.13",
     "babelify": "^7.2.0",
-    "browserify": "11.0.1"
+    "browserify": "11.0.1",
+    "mocha": "^3.2.0"
   },
   "author": "Giovanni T. Parra",
   "license": "MIT",

--- a/test.js
+++ b/test.js
@@ -1,8 +1,6 @@
 var assert = require('assert');
 
-var run = require('@cycle/most-run').default;
 var adapter = require('@cycle/most-adapter').default;
-
 var most = require('most');
 
 var gql = require('graphql-tag');

--- a/test.js
+++ b/test.js
@@ -1,0 +1,51 @@
+var assert = require('assert');
+
+var run = require('@cycle/most-run').default;
+var adapter = require('@cycle/most-adapter').default;
+
+var most = require('most');
+
+var gql = require('graphql-tag');
+
+var { makeGraphQLDriver } = require('./index');
+
+// fake ApolloClient for testing
+const client = {
+  query: ({query, variables, forFetch}) => new Promise( (resolve, reject) => {
+    resolve({id: 1, name: 'WidgetOne'});
+  })
+};
+
+describe('GraphQL Driver', function() {
+  it('should return an item', function(done) {
+
+    var graphQLDriver = makeGraphQLDriver({
+      client: client,
+      templates: {
+        fetchItem: gql`
+         query fetchItem($id: ID!) {
+           item(id: $id) {
+             id
+             name
+           }
+         }`
+      }
+    });
+
+    var input = most.from([{
+      query: 'fetchItem',
+      variables: {
+        id: 1
+      }
+    }])
+
+    var output = graphQLDriver(input, adapter);
+
+    output.forEach( ({id, name}) => {
+      assert.equal(id, 1);
+      assert.equal(name, 'WidgetOne');
+      done();
+    });
+
+  });
+});


### PR DESCRIPTION
Hi! I was playing with CycleJS+Apollo and I stumbled upon this repo.

I made your driver implementation independent from most. I used `runStreamAdapter`. I am new to CycleJS and I am not sure if it is the best way. I was curious to know what you think about.

Then I removed the definition of `ApolloClient` and `NetworkInterface` from the driver. You can pass an `ApolloClient` in the driver constructor. In this way the driver is independent from the kind of `NetworkInterface`. For example `use` method is available only for `HttpNetworkInterface` and it does not make sense in other contexts.

Unfortunately, in this way, it is not possible to emit headers as you did in your code. Perhaps can we delegate the control of this behaviour to the main app?